### PR TITLE
Check if required inputs exist in pipeline.sh

### DIFF
--- a/src/pipeline.sh
+++ b/src/pipeline.sh
@@ -19,6 +19,21 @@ export PATH=$PATH:$ANTSPATH:/extra/ANTS/ANTs/Scripts
 # Set up pytorch
 source /extra/pytorch/bin/activate
 
+# Check input
+if [[ ! -f /INPUTS/b0.nii.gz ]]; then
+	echo ERROR: Could not find required input /INPUTS/b0.nii.gz
+	exit 
+elif [[ ! -f /INPUTS/T1.nii.gz ]]; then
+	echo ERROR: Could not find required input /INPUTS/T1.nii.gz
+	exit
+elif [[ ! -f /INPUTS/acqparams.txt ]]; then
+	echo ERROR: Could not find required input /INPUTS/acqparams.txt
+	exit
+elif [[ ! -f /extra/freesurfer/license.txt ]]; then
+	echo ERROR: Could not find required /extra/freesurfer/license.txt
+	exit
+fi
+
 # Prepare input
 prepare_input.sh /INPUTS/b0.nii.gz /INPUTS/T1.nii.gz /extra/atlases/mni_icbm152_t1_tal_nlin_asym_09c.nii.gz /extra/atlases/mni_icbm152_t1_tal_nlin_asym_09c_2_5.nii.gz /OUTPUTS
 


### PR DESCRIPTION
Added a check for existence of required inputs to `pipeline.sh` based on required input in README and assuming directory structure of docker/singularity.

Currently, if the b0 input doesn't match exactly `b0.nii.gz` then the pipeline will only fail after working for a while on the `T1.nii.gz`, with the `prepare_input.sh` script still indicating the `b0.nii.gz` input exists.

Discovered this when an upstream process named the b0 input as `b0_tmp.nii.gz` rather than `b0.nii.gz`. Intended that these checks catch this type of oversight early.

Note: I ran dos2unix to test this locally via docker, and unix2dos before commit.

(This is my first PR so I'm open to feedback!)